### PR TITLE
Finalize Seed Designs. Closes #9

### DIFF
--- a/symbench_athens_client/models/designs.py
+++ b/symbench_athens_client/models/designs.py
@@ -45,26 +45,26 @@ class SeedDesign(BaseModel):
 class QuadCopter(SeedDesign):
     """The quadcopter seed design"""
 
-    arm_length: int = Field(
-        220,
+    arm_length: float = Field(
+        220.0,
         description="Length of Arm_0, Arm_1, Arm_2, Arm_3 in mm",
         alias="Length_0",
     )
 
-    support_length: int = Field(
-        95,
+    support_length: float = Field(
+        95.0,
         description="Length of support_0, Support_1, Support_2, Support_3 in mm",
         alias="Length_1",
     )
 
-    batt_mount_x_offset: int = Field(
-        0,
+    batt_mount_x_offset: float = Field(
+        0.0,
         description="X-Offset of the battery mounting position from center of the plate in mm",
         alias="Length_2",
     )
 
-    batt_mount_z_offset: int = Field(
-        0,
+    batt_mount_z_offset: float = Field(
+        0.0,
         description="Z-Offset of the battery mounting position from center of the plate in mm",
         alias="Length_3",
     )
@@ -73,83 +73,76 @@ class QuadCopter(SeedDesign):
 class QuadSpiderCopter(SeedDesign):
     """The QuadSpiderCopter seed design."""
 
-    arm_length: int = Field(
-        220,
+    arm_length: float = Field(
+        220.0,
         description="Length of Arm_0, Arm_1, Arm_2, Arm_3 in mm",
         alias="Length_0",
     )
 
-    support_length: int = Field(
-        155,
+    support_length: float = Field(
+        155.0,
         description="Length for Support_0, Support_1, Support_2, Support_3 in mm",
         alias="Length_1",
     )
 
-    arm_a_length: int = Field(
-        80,
+    arm_a_length: float = Field(
+        80.0,
         description="Length for Arm_0a, Arm_1a, Arm_2a, Arm_3a in mm",
         alias="Length_2",
     )
 
-    arm_b_length: int = Field(
-        80, description="Length of segment Arm_*b in mm", alias="Length_3"
+    arm_b_length: float = Field(
+        80.0, description="Length of segment Arm_*b in mm", alias="Length_3"
     )
 
     batt_mount_x_offset: float = Field(
-        200.00,
+        0.0,
         description="X-Offset of the battery mounting position from center of the plate in mm",
         alias="Length_4",
     )
 
     batt_mount_z_offset: float = Field(
-        200.00,
+        0.0,
         description="Z-Offset of the battery mounting position from center of the plate in mm",
         alias="Length_5",
     )
 
-    bend_angle: int = Field(
-        120,
+    bend_angle: float = Field(
+        120.0,
         description="ANGHORZCONN for Bend_0a, Bend_0b, Bend_1a, Bend_1b, Bend_2a, Bend_2b, Bend_3a, Bend_3b",
         alias="Param_0",
     )
 
-    @root_validator(pre=True)
-    def validate_angle_rot_b(cls, values):
-        rot_a = values.get("rot_a", 90.00)
-        rot_b = values.get("rot_b", -90.00)
-        assert rot_a + rot_b == 0.0, "Sum of Rot_a and Rot_b should be zero"
-        return values
-
 
 class HCopter(SeedDesign):
-    arm_length: int = Field(
-        500,
+    arm_length: float = Field(
+        500.0,
         description="Length of Arm_0, Arm_1, Arm_2, Arm_3 in mm (default 500)",
         alias="Length_0",
     )
 
-    support_length: int = Field(
-        95,
+    support_length: float = Field(
+        95.0,
         description="Length of Support_0, Support_1, Support_2, Support_3 in mm (default 95)",
         alias="Length_1",
     )
 
-    batt_mount_x_offset: int = Field(
-        0,
+    batt_mount_x_offset: float = Field(
+        0.0,
         description="X Offset of battery mounting position from center of plate in mm (default 0)",
         alias="Length_2",
     )
 
-    batt_mount_z_offset: int = Field(
-        0,
+    batt_mount_z_offset: float = Field(
+        0.0,
         description="Z Offset of battery mounting position from center of plate in mm (default 0)",
         alias="Length_3",
     )
 
 
 class HPlane(SeedDesign):
-    tube_length: int = Field(
-        320,
+    tube_length: float = Field(
+        320.0,
         description="Length for Body_Tube_Front_L, Body_Tube_Front_R, "
         "Body_Tube_Rear_L, Body_Tube_Rear_R in mm (default 320) "
         "Length in x. Do not put props under wings",
@@ -159,3 +152,15 @@ class HPlane(SeedDesign):
 
 class HexRing(SeedDesign):
     pass
+
+
+default_params = {}
+default_params["QuadCopter"] = QuadCopter().to_jenkins_parameters()
+default_params["QuadSpiderCopter"] = QuadSpiderCopter().to_jenkins_parameters()
+default_params["Hplane"] = HPlane().to_jenkins_parameters()
+default_params["HCopter"] = HCopter().to_jenkins_parameters()
+
+with open("default_params.json", "w") as json_file:
+    import json
+
+    json.dump(default_params, json_file, indent=2)

--- a/symbench_athens_client/tests/models/test_designs.py
+++ b/symbench_athens_client/tests/models/test_designs.py
@@ -1,7 +1,12 @@
 import pytest
 from pydantic import ValidationError
 
-from symbench_athens_client.models.designs import QuadCopter, QuadSpiderCopter
+from symbench_athens_client.models.designs import (
+    HCopter,
+    HPlane,
+    QuadCopter,
+    QuadSpiderCopter,
+)
 
 
 class TestDesigns:
@@ -13,24 +18,35 @@ class TestDesigns:
     def qd_spider_copter(self):
         return QuadSpiderCopter()
 
+    @pytest.fixture(scope="session")
+    def h_plane(self):
+        return HPlane()
+
+    @pytest.fixture(scope="session")
+    def h_copter(self):
+        return HCopter()
+
     def test_quadcopter_jenkins_params(self, qd_copter):
         params = qd_copter.to_jenkins_parameters()
-        assert "Length_0" in params
-        assert "Length_1" in params
-        assert "Length_2" in params
-        assert "Length_3" in params
+        assert (
+            params["DesignVars"]
+            == "Length_0=220.0,220.0 Length_1=95.0,95.0 Length_2=0.0,0.0 Length_3=0.0,0.0"
+        )
 
     def test_quadcopter_jenkins_params(self, qd_spider_copter):
-        params = qd_spider_copter.to_jenkins_parameters()["DesignVars"]
-        assert "Length_0=200.0" in params
-        assert "Length_1=200.0" in params
-        assert "Length_2=200.0" in params
-        assert "Length_3=200.0" in params
-        assert "Rot_a=90.0" in params
-        assert "Rot_b=-90.0" in params
-        assert "Length_4" in params
-        assert "Length_5" in params
+        params = qd_spider_copter.to_jenkins_parameters()
+        assert (
+            params["DesignVars"]
+            == "Length_0=220.0,220.0 Length_1=155.0,155.0 Length_2=80.0,80.0 Length_3=80.0,80.0 Length_4=0.0,0.0 Length_5=0.0,0.0 Param_0=120.0,120.0"
+        )
 
-    def test_qd_spider_sum_non_zero(self):
-        with pytest.raises(ValidationError):
-            QuadSpiderCopter(rot_a=90, rot_b=189)
+    def test_hplane_jenkins_params(self, h_plane):
+        params = h_plane.to_jenkins_parameters()
+        assert params["DesignVars"] == "Length_1=320.0,320.0"
+
+    def test_hcopter_jenkins_params(self, h_copter):
+        params = h_copter.to_jenkins_parameters()
+        assert (
+            params["DesignVars"]
+            == "Length_0=500.0,500.0 Length_1=95.0,95.0 Length_2=0.0,0.0 Length_3=0.0,0.0"
+        )


### PR DESCRIPTION
For now, I have decided to keep these design classes with very few variables as the goal is to execute the workflows and only configurable parameters to be exposed. 
All together there are five seed designs, and one of them `HexRing` is not working in the SWRI tool chain.

## Current Designs:
- [x] QuadCopter
- [x] QuadSpiderCopter
- [ ] HexRing (Not Working in the SWRI Toolchain)
- [x] HPlane
- [x] HCopter

## Default DesignVar Values:
~~ToDo. I will create a script to generate default values and ask mary/team members to verify it.~~

```python
from symbench_athens_client.models.designs import QuadCopter, QuadSpiderCopter, HPlane, HCopter
default_params = {}
default_params['QuadCopter'] = QuadCopter().to_jenkins_parameters()
default_params['QuadSpiderCopter'] = QuadSpiderCopter().to_jenkins_parameters()
default_params['Hplane'] = HPlane().to_jenkins_parameters()
default_params['HCopter'] = HCopter().to_jenkins_parameters()

with open('default_params.json.txt', 'w') as json_file:
    import json
    json.dump(default_params, json_file, indent=2)
```

[default_params.json.txt](https://github.com/symbench/symbench-athens-client/files/6941315/default_params.json.txt)